### PR TITLE
Set blockSize to 512

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hanwen/go-mtpfs/mtp"
 )
 
-const blockSize = 1024
+const blockSize = 512
 
 type DeviceFsOptions struct {
 	// Assume removable volumes are VFAT and munge filenames


### PR DESCRIPTION
This fixes size reported by du, which assumes blocks are given in 512
byte pieces.

See the bug #98 for what this change is related to.

When I started to look into it more, I found that the stat man page says:
> The st_blocks field indicates the number of blocks allocated to the file, 512-byte units. (This may be smaller than st_size/512 when the file has holes.) 

So it looks like the block size should definitely be 512.

I also checked the program `ncdu` and see that it is using a size of 512 when calculating its "disk usage", as further support that this is the right change.