### PR TITLE
Use GetPartialObject() in classic mode when possible

### DIFF
--- a/mtp/ops.go
+++ b/mtp/ops.go
@@ -216,7 +216,7 @@ func (d *Device) GetObject(handle uint32, w io.Writer) error {
 
 func (d *Device) GetPartialObject(handle uint32, w io.Writer, offset uint32, size uint32) error {
 	var req, rep Container
-	req.Code = OC_ANDROID_GET_PARTIAL_OBJECT64
+	req.Code = OC_GetPartialObject
 	req.Param = []uint32{handle, offset, size}
 	return d.RunTransaction(&req, &rep, w, nil, 0)
 }


### PR DESCRIPTION
Some Android devices do not seem to implement the Android MTP extensions, yet still support GetPartialObject. Use it when the file size is less than MaxUint32 and when there aren't any pending writes to file being read.

NOTE: this works for me, though I am still hitting the `fatal error got type 0 (CONTAINER_UNDEFINED) in response, want CONTAINER_RESPONSE.; closing connection` bug from time to time; which I'm taking is unrelated to this change (as this is a high-level change and that bug is more lower-level related)