### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -45,7 +45,7 @@ type deviceFS struct {
 	options *DeviceFsOptions
 }
 
-// DeviceFs is a simple filesystem interface to an MTP device. It
+// NewDeviceFSRoot is a simple filesystem interface to an MTP device. It
 // should be wrapped in a Locking(Raw)FileSystem to make sure it is
 // threadsafe.  The file system assumes the device does not touch the
 // storage.  Arguments are the opened mtp device and a directory for the

--- a/mtp/select.go
+++ b/mtp/select.go
@@ -130,7 +130,7 @@ func selectDevice(cands []*Device, pattern string) (*Device, error) {
 	return found[0], nil
 }
 
-// Return opened MTP device that matches given pattern.
+// SelectDevice returns opened MTP device that matches given pattern.
 func SelectDevice(pattern string) (*Device, error) {
 	c := usb.NewContext()
 


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._